### PR TITLE
feat: フロントエンドデザインのアップデート

### DIFF
--- a/src/features/blog/components/BlogCard.astro
+++ b/src/features/blog/components/BlogCard.astro
@@ -7,45 +7,15 @@ const { id, title, category, category2, publishedAt } = Astro.props;
 const date = formatDate(publishedAt);
 ---
 
-<div class="card">
-  <a href=`/blogs/${id}`>
-    <h2>{title}</h2>
+<div class="p-4 rounded-lg h-full border border-border">
+  <a href=`/blogs/${id}` class="text-inherit no-underline hover:text-muted-foreground hover:no-underline">
+    <h2 class="text-lg">{title}</h2>
   </a>
-  <div class="flex">
+  <div class="flex justify-between items-center">
     <div>
       {category && <CategoryBadge {...category} />}
       {category2 && <CategoryBadge {...category2} />}
     </div>
-    <p>{date}</p>
+    <p class="m-0">{date}</p>
   </div>
 </div>
-
-<style>
-  h2 {
-    font-size: 1.2rem;
-  }
-  a {
-    color: inherit;
-  }
-  a:hover {
-    color: gray;
-    text-decoration: none;
-  }
-
-  p {
-    margin: 0;
-  }
-
-  .card {
-    padding: 1rem;
-    border: 1px solid #ccc;
-    border-radius: 0.5rem;
-    height: 100%;
-  }
-
-  .flex {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-</style>

--- a/src/features/blog/components/CategoryBadge.astro
+++ b/src/features/blog/components/CategoryBadge.astro
@@ -19,13 +19,13 @@ const BACK_END = ["Node.js", "Nest.js", "Prisma", "Go"] as const;
 const TOOLS = ["Github", "Git", "Docker", "Vercel", "Cloudflare"] as const;
 
 const getCategoryColorClass = (label: typeof name): string => {
-	if (FRONT_END.some((item) => item === label)) {
+	if (FRONT_END.includes(label)) {
 		return "bg-amber-500 dark:bg-amber-600";
 	}
-	if (BACK_END.some((item) => item === label)) {
+	if (BACK_END.includes(label)) {
 		return "bg-blue-600 dark:bg-blue-500";
 	}
-	if (TOOLS.some((item) => item === label)) {
+	if (TOOLS.includes(label)) {
 		return "bg-emerald-500 dark:bg-emerald-600";
 	}
 	return "bg-gray-500 dark:bg-gray-600";

--- a/src/features/blog/components/CategoryBadge.astro
+++ b/src/features/blog/components/CategoryBadge.astro
@@ -18,44 +18,20 @@ const FRONT_END = [
 const BACK_END = ["Node.js", "Nest.js", "Prisma", "Go"] as const;
 const TOOLS = ["Github", "Git", "Docker", "Vercel", "Cloudflare"] as const;
 
-const makeClass = (label: typeof name) => {
+const getCategoryColorClass = (label: typeof name): string => {
 	if (FRONT_END.some((item) => item === label)) {
-		return "bg-yellow-500";
+		return "bg-amber-500 dark:bg-amber-600";
 	}
 	if (BACK_END.some((item) => item === label)) {
-		return "bg-blue-500";
+		return "bg-blue-600 dark:bg-blue-500";
 	}
 	if (TOOLS.some((item) => item === label)) {
-		return "bg-green-500";
+		return "bg-emerald-500 dark:bg-emerald-600";
 	}
-	return "bg-gray-500";
+	return "bg-gray-500 dark:bg-gray-600";
 };
 ---
 
-<div class={`${makeClass(name)}`}>
+<div class={`inline-block px-2 py-1 rounded text-white text-xs ${getCategoryColorClass(name)}`}>
   {name}
 </div>
-
-<style>
-  .bg-yellow-500 {
-    background-color: #f59e0b;
-  }
-  .bg-blue-500 {
-    background-color: #2563eb;
-  }
-  .bg-green-500 {
-    background-color: #10b981;
-  }
-  .bg-gray-500 {
-    background-color: #6b7280;
-  }
-  div {
-    font-family: Arial, Helvetica, sans-serif;
-    display: inline-block;
-    padding: 0.2rem 0.3rem;
-    line-height: 1.2;
-    border-radius: 0.25rem;
-    color: white;
-    font-size: 0.75rem;
-  }
-</style>

--- a/src/shared/components/layout/Header.astro
+++ b/src/shared/components/layout/Header.astro
@@ -7,7 +7,7 @@ import { Icon } from "astro-icon/components";
 ---
 
 <header>
-  <nav class="mb-4 justify-between h-12 bg-slate-200 dark:bg-slate-900">
+  <nav class="mb-4 justify-between h-12 bg-secondary">
     <div
       class="container h-full flex justify-between items-center bg-clip-padding"
     >

--- a/src/shared/components/ui/alert.tsx
+++ b/src/shared/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+	"relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+	{
+		variants: {
+			variant: {
+				default: "bg-background text-foreground",
+				success:
+					"border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100 [&>svg]:text-emerald-600 dark:[&>svg]:text-emerald-400",
+				warning:
+					"border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100 [&>svg]:text-amber-600 dark:[&>svg]:text-amber-400",
+				destructive:
+					"border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive dark:bg-destructive/20 dark:text-red-200 [&>svg]:text-destructive dark:[&>svg]:text-red-400",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+export interface AlertProps
+	extends React.HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof alertVariants> {}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+	({ className, variant, ...props }, ref) => (
+		<div
+			ref={ref}
+			role="alert"
+			className={cn(alertVariants({ variant }), className)}
+			{...props}
+		/>
+	),
+);
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+	<h5
+		ref={ref}
+		className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+		{...props}
+	/>
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		className={cn("text-sm [&_p]:leading-relaxed", className)}
+		{...props}
+	/>
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription, alertVariants };

--- a/src/shared/components/ui/alert.tsx
+++ b/src/shared/components/ui/alert.tsx
@@ -40,7 +40,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
 Alert.displayName = "Alert";
 
 const AlertTitle = React.forwardRef<
-	HTMLParagraphElement,
+	HTMLHeadingElement,
 	React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
 	<h5
@@ -52,8 +52,8 @@ const AlertTitle = React.forwardRef<
 AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = React.forwardRef<
-	HTMLParagraphElement,
-	React.HTMLAttributes<HTMLParagraphElement>
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
 	<div
 		ref={ref}

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 import {
 	createContext,

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import * as React from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+// ============================================================================
+// Dialog Context
+// ============================================================================
+
+interface DialogContextValue {
+	open: boolean;
+	setOpen: (open: boolean) => void;
+	titleId: string;
+	descriptionId: string;
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+function useDialogContext() {
+	const context = useContext(DialogContext);
+	if (!context) {
+		throw new Error("Dialog components must be used within a Dialog");
+	}
+	return context;
+}
+
+// ============================================================================
+// Dialog (Root)
+// ============================================================================
+
+interface DialogProps {
+	children: React.ReactNode;
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	defaultOpen?: boolean;
+}
+
+const Dialog: React.FC<DialogProps> = ({
+	children,
+	open: controlledOpen,
+	onOpenChange,
+	defaultOpen = false,
+}) => {
+	const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+	const uniqueId = useId();
+
+	const isControlled = controlledOpen !== undefined;
+	const open = isControlled ? controlledOpen : uncontrolledOpen;
+
+	const setOpen = useCallback(
+		(newOpen: boolean) => {
+			if (!isControlled) {
+				setUncontrolledOpen(newOpen);
+			}
+			onOpenChange?.(newOpen);
+		},
+		[isControlled, onOpenChange],
+	);
+
+	const titleId = `dialog-title-${uniqueId}`;
+	const descriptionId = `dialog-description-${uniqueId}`;
+
+	return (
+		<DialogContext.Provider value={{ open, setOpen, titleId, descriptionId }}>
+			{children}
+		</DialogContext.Provider>
+	);
+};
+Dialog.displayName = "Dialog";
+
+// ============================================================================
+// DialogTrigger
+// ============================================================================
+
+interface DialogTriggerProps
+	extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+	asChild?: boolean;
+}
+
+const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
+	({ children, asChild, onClick, ...props }, ref) => {
+		const { setOpen } = useDialogContext();
+
+		const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+			onClick?.(e);
+			setOpen(true);
+		};
+
+		if (asChild && React.isValidElement(children)) {
+			return React.cloneElement(
+				children as React.ReactElement<{
+					onClick?: (e: React.MouseEvent) => void;
+				}>,
+				{
+					onClick: (e: React.MouseEvent) => {
+						(
+							children as React.ReactElement<{
+								onClick?: (e: React.MouseEvent) => void;
+							}>
+						).props.onClick?.(e);
+						setOpen(true);
+					},
+				},
+			);
+		}
+
+		return (
+			<button ref={ref} type="button" onClick={handleClick} {...props}>
+				{children}
+			</button>
+		);
+	},
+);
+DialogTrigger.displayName = "DialogTrigger";
+
+// ============================================================================
+// DialogPortal
+// ============================================================================
+
+interface DialogPortalProps {
+	children: React.ReactNode;
+}
+
+const DialogPortal: React.FC<DialogPortalProps> = ({ children }) => {
+	const { open } = useDialogContext();
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	if (!mounted || !open) {
+		return null;
+	}
+
+	return <>{children}</>;
+};
+DialogPortal.displayName = "DialogPortal";
+
+// ============================================================================
+// DialogOverlay
+// ============================================================================
+
+interface DialogOverlayProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const DialogOverlay = React.forwardRef<HTMLDivElement, DialogOverlayProps>(
+	({ className, ...props }, ref) => {
+		const { open } = useDialogContext();
+		const [isVisible, setIsVisible] = useState(false);
+
+		useEffect(() => {
+			if (open) {
+				requestAnimationFrame(() => {
+					setIsVisible(true);
+				});
+			} else {
+				setIsVisible(false);
+			}
+		}, [open]);
+
+		return (
+			<div
+				ref={ref}
+				className={cn(
+					"fixed inset-0 z-50 bg-black/50 transition-opacity duration-200",
+					isVisible ? "opacity-100" : "opacity-0",
+					className,
+				)}
+				{...props}
+			/>
+		);
+	},
+);
+DialogOverlay.displayName = "DialogOverlay";
+
+// ============================================================================
+// DialogContent
+// ============================================================================
+
+interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
+	({ className, children, ...props }, ref) => {
+		const { open, setOpen, titleId, descriptionId } = useDialogContext();
+		const [isVisible, setIsVisible] = useState(false);
+		const contentRef = useRef<HTMLDivElement>(null);
+		const previousActiveElement = useRef<HTMLElement | null>(null);
+
+		// フォーカス管理とアニメーション
+		useEffect(() => {
+			if (open) {
+				previousActiveElement.current = document.activeElement as HTMLElement;
+				document.body.style.overflow = "hidden";
+
+				requestAnimationFrame(() => {
+					setIsVisible(true);
+					// ダイアログ内の最初のフォーカス可能な要素にフォーカス
+					const focusableElements =
+						contentRef.current?.querySelectorAll<HTMLElement>(
+							'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+						);
+					if (focusableElements && focusableElements.length > 0) {
+						focusableElements[0].focus();
+					}
+				});
+			} else {
+				setIsVisible(false);
+				document.body.style.overflow = "";
+				previousActiveElement.current?.focus();
+			}
+
+			return () => {
+				document.body.style.overflow = "";
+			};
+		}, [open]);
+
+		// ESCキーで閉じる
+		useEffect(() => {
+			const handleKeyDown = (e: KeyboardEvent) => {
+				if (e.key === "Escape" && open) {
+					setOpen(false);
+				}
+			};
+
+			document.addEventListener("keydown", handleKeyDown);
+			return () => document.removeEventListener("keydown", handleKeyDown);
+		}, [open, setOpen]);
+
+		// フォーカストラップ
+		useEffect(() => {
+			const handleKeyDown = (e: KeyboardEvent) => {
+				if (e.key !== "Tab" || !open) return;
+
+				const focusableElements =
+					contentRef.current?.querySelectorAll<HTMLElement>(
+						'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+					);
+
+				if (!focusableElements || focusableElements.length === 0) return;
+
+				const firstElement = focusableElements[0];
+				const lastElement = focusableElements[focusableElements.length - 1];
+
+				if (e.shiftKey) {
+					if (document.activeElement === firstElement) {
+						e.preventDefault();
+						lastElement.focus();
+					}
+				} else {
+					if (document.activeElement === lastElement) {
+						e.preventDefault();
+						firstElement.focus();
+					}
+				}
+			};
+
+			document.addEventListener("keydown", handleKeyDown);
+			return () => document.removeEventListener("keydown", handleKeyDown);
+		}, [open]);
+
+		return (
+			<DialogPortal>
+				<DialogOverlay />
+				<div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+					<div
+						ref={(node) => {
+							contentRef.current = node;
+							if (typeof ref === "function") {
+								ref(node);
+							} else if (ref) {
+								ref.current = node;
+							}
+						}}
+						role="dialog"
+						aria-modal="true"
+						aria-labelledby={titleId}
+						aria-describedby={descriptionId}
+						className={cn(
+							"relative w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg transition-all duration-200",
+							isVisible ? "scale-100 opacity-100" : "scale-95 opacity-0",
+							className,
+						)}
+						{...props}
+					>
+						{children}
+					</div>
+				</div>
+			</DialogPortal>
+		);
+	},
+);
+DialogContent.displayName = "DialogContent";
+
+// ============================================================================
+// DialogHeader
+// ============================================================================
+
+interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const DialogHeader = React.forwardRef<HTMLDivElement, DialogHeaderProps>(
+	({ className, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn(
+				"flex flex-col space-y-1.5 text-center sm:text-left",
+				className,
+			)}
+			{...props}
+		/>
+	),
+);
+DialogHeader.displayName = "DialogHeader";
+
+// ============================================================================
+// DialogTitle
+// ============================================================================
+
+interface DialogTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+const DialogTitle = React.forwardRef<HTMLHeadingElement, DialogTitleProps>(
+	({ className, ...props }, ref) => {
+		const { titleId } = useDialogContext();
+
+		return (
+			<h2
+				ref={ref}
+				id={titleId}
+				className={cn(
+					"text-lg font-semibold leading-none tracking-tight",
+					className,
+				)}
+				{...props}
+			/>
+		);
+	},
+);
+DialogTitle.displayName = "DialogTitle";
+
+// ============================================================================
+// DialogDescription
+// ============================================================================
+
+interface DialogDescriptionProps
+	extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+const DialogDescription = React.forwardRef<
+	HTMLParagraphElement,
+	DialogDescriptionProps
+>(({ className, ...props }, ref) => {
+	const { descriptionId } = useDialogContext();
+
+	return (
+		<p
+			ref={ref}
+			id={descriptionId}
+			className={cn("text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+});
+DialogDescription.displayName = "DialogDescription";
+
+// ============================================================================
+// DialogFooter
+// ============================================================================
+
+interface DialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>(
+	({ className, ...props }, ref) => (
+		<div
+			ref={ref}
+			className={cn(
+				"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+				className,
+			)}
+			{...props}
+		/>
+	),
+);
+DialogFooter.displayName = "DialogFooter";
+
+// ============================================================================
+// DialogClose
+// ============================================================================
+
+interface DialogCloseProps
+	extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
+	({ className, children, onClick, ...props }, ref) => {
+		const { setOpen } = useDialogContext();
+
+		const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+			onClick?.(e);
+			setOpen(false);
+		};
+
+		return (
+			<button
+				ref={ref}
+				type="button"
+				className={cn(
+					"absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none",
+					className,
+				)}
+				onClick={handleClick}
+				aria-label="Close"
+				{...props}
+			>
+				{children || (
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="24"
+						height="24"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						className="h-4 w-4"
+						aria-hidden="true"
+					>
+						<path d="M18 6 6 18" />
+						<path d="m6 6 12 12" />
+					</svg>
+				)}
+			</button>
+		);
+	},
+);
+DialogClose.displayName = "DialogClose";
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+	Dialog,
+	DialogTrigger,
+	DialogPortal,
+	DialogOverlay,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogDescription,
+	DialogFooter,
+	DialogClose,
+};

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -223,49 +223,43 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
 			};
 		}, [open]);
 
-		// ESCキーで閉じる
+		// ESCキーで閉じる & フォーカストラップ
 		useEffect(() => {
 			const handleKeyDown = (e: KeyboardEvent) => {
-				if (e.key === "Escape" && open) {
+				if (!open) return;
+
+				if (e.key === "Escape") {
 					setOpen(false);
+				}
+
+				if (e.key === "Tab") {
+					const focusableElements =
+						contentRef.current?.querySelectorAll<HTMLElement>(
+							'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+						);
+
+					if (!focusableElements || focusableElements.length === 0) return;
+
+					const firstElement = focusableElements[0];
+					const lastElement = focusableElements[focusableElements.length - 1];
+
+					if (e.shiftKey) {
+						if (document.activeElement === firstElement) {
+							e.preventDefault();
+							lastElement.focus();
+						}
+					} else {
+						if (document.activeElement === lastElement) {
+							e.preventDefault();
+							firstElement.focus();
+						}
+					}
 				}
 			};
 
 			document.addEventListener("keydown", handleKeyDown);
 			return () => document.removeEventListener("keydown", handleKeyDown);
 		}, [open, setOpen]);
-
-		// フォーカストラップ
-		useEffect(() => {
-			const handleKeyDown = (e: KeyboardEvent) => {
-				if (e.key !== "Tab" || !open) return;
-
-				const focusableElements =
-					contentRef.current?.querySelectorAll<HTMLElement>(
-						'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-					);
-
-				if (!focusableElements || focusableElements.length === 0) return;
-
-				const firstElement = focusableElements[0];
-				const lastElement = focusableElements[focusableElements.length - 1];
-
-				if (e.shiftKey) {
-					if (document.activeElement === firstElement) {
-						e.preventDefault();
-						lastElement.focus();
-					}
-				} else {
-					if (document.activeElement === lastElement) {
-						e.preventDefault();
-						firstElement.focus();
-					}
-				}
-			};
-
-			document.addEventListener("keydown", handleKeyDown);
-			return () => document.removeEventListener("keydown", handleKeyDown);
-		}, [open]);
 
 		return (
 			<DialogPortal>

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -8,6 +8,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 import { cn } from "@/lib/utils";
 
@@ -137,11 +138,11 @@ const DialogPortal: React.FC<DialogPortalProps> = ({ children }) => {
 		setMounted(true);
 	}, []);
 
-	if (!mounted || !open) {
+	if (!open) {
 		return null;
 	}
 
-	return <>{children}</>;
+	return mounted ? createPortal(children, document.body) : null;
 };
 DialogPortal.displayName = "DialogPortal";
 

--- a/src/shared/components/ui/toast.tsx
+++ b/src/shared/components/ui/toast.tsx
@@ -1,0 +1,185 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+import { useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import type { Toast as ToastType, ToastVariant } from "./use-toast";
+
+const toastVariants = cva(
+	"pointer-events-auto relative flex w-full items-center justify-between gap-4 overflow-hidden rounded-md border p-4 pr-8 shadow-lg transition-all",
+	{
+		variants: {
+			variant: {
+				success:
+					"border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-950 dark:text-green-100",
+				error:
+					"border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive dark:bg-destructive/20 dark:text-red-200",
+				warning:
+					"border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100",
+				info: "border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100",
+			},
+		},
+		defaultVariants: {
+			variant: "info",
+		},
+	},
+);
+
+const iconMap: Record<ToastVariant, React.ReactNode> = {
+	success: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className="h-5 w-5 text-green-600 dark:text-green-400"
+			aria-hidden="true"
+		>
+			<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+			<path d="m9 11 3 3L22 4" />
+		</svg>
+	),
+	error: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className="h-5 w-5 text-destructive dark:text-red-400"
+			aria-hidden="true"
+		>
+			<circle cx="12" cy="12" r="10" />
+			<line x1="15" x2="9" y1="9" y2="15" />
+			<line x1="9" x2="15" y1="9" y2="15" />
+		</svg>
+	),
+	warning: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className="h-5 w-5 text-amber-600 dark:text-amber-400"
+			aria-hidden="true"
+		>
+			<path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+			<path d="M12 9v4" />
+			<path d="M12 17h.01" />
+		</svg>
+	),
+	info: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className="h-5 w-5 text-blue-600 dark:text-blue-400"
+			aria-hidden="true"
+		>
+			<circle cx="12" cy="12" r="10" />
+			<path d="M12 16v-4" />
+			<path d="M12 8h.01" />
+		</svg>
+	),
+};
+
+export interface ToastProps
+	extends React.HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof toastVariants> {
+	toast: ToastType;
+	onDismiss: (id: string) => void;
+}
+
+const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
+	({ className, toast: toastData, onDismiss, ...props }, ref) => {
+		const [isVisible, setIsVisible] = useState(false);
+		const [isLeaving, setIsLeaving] = useState(false);
+
+		useEffect(() => {
+			// マウント時にアニメーション開始
+			const showTimer = requestAnimationFrame(() => {
+				setIsVisible(true);
+			});
+
+			return () => cancelAnimationFrame(showTimer);
+		}, []);
+
+		const handleDismiss = React.useCallback(() => {
+			setIsLeaving(true);
+			setTimeout(() => {
+				onDismiss(toastData.id);
+			}, 150); // アニメーション完了を待つ
+		}, [onDismiss, toastData.id]);
+
+		useEffect(() => {
+			if (toastData.duration && toastData.duration > 0) {
+				const timer = setTimeout(() => {
+					handleDismiss();
+				}, toastData.duration);
+
+				return () => clearTimeout(timer);
+			}
+		}, [toastData.duration, handleDismiss]);
+
+		return (
+			<div
+				ref={ref}
+				className={cn(
+					toastVariants({ variant: toastData.variant }),
+					"transform transition-all duration-150 ease-out",
+					isVisible && !isLeaving
+						? "translate-x-0 opacity-100"
+						: "translate-x-full opacity-0",
+					className,
+				)}
+				{...props}
+			>
+				<div className="flex items-start gap-3">
+					<div className="shrink-0">{iconMap[toastData.variant]}</div>
+					<div className="grid gap-1">
+						<div className="text-sm font-semibold">{toastData.title}</div>
+						{toastData.description && (
+							<div className="text-sm opacity-90">{toastData.description}</div>
+						)}
+					</div>
+				</div>
+				<button
+					onClick={handleDismiss}
+					className="absolute right-2 top-2 rounded-md p-1 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2"
+					type="button"
+					aria-label="Close"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						className="h-4 w-4"
+						aria-hidden="true"
+					>
+						<path d="M18 6 6 18" />
+						<path d="m6 6 12 12" />
+					</svg>
+				</button>
+			</div>
+		);
+	},
+);
+Toast.displayName = "Toast";
+
+export { Toast, toastVariants };

--- a/src/shared/components/ui/toast.tsx
+++ b/src/shared/components/ui/toast.tsx
@@ -11,7 +11,7 @@ const toastVariants = cva(
 		variants: {
 			variant: {
 				success:
-					"border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-950 dark:text-green-100",
+					"border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100",
 				error:
 					"border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive dark:bg-destructive/20 dark:text-red-200",
 				warning:
@@ -35,7 +35,7 @@ const iconMap: Record<ToastVariant, React.ReactNode> = {
 			strokeWidth="2"
 			strokeLinecap="round"
 			strokeLinejoin="round"
-			className="h-5 w-5 text-green-600 dark:text-green-400"
+			className="h-5 w-5 text-emerald-600 dark:text-emerald-400"
 			aria-hidden="true"
 		>
 			<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />

--- a/src/shared/components/ui/toast.tsx
+++ b/src/shared/components/ui/toast.tsx
@@ -157,7 +157,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
 				</div>
 				<button
 					onClick={handleDismiss}
-					className="absolute right-2 top-2 rounded-md p-1 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2"
+					className="absolute right-2 top-2 rounded-md p-1 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
 					type="button"
 					aria-label="Close"
 				>

--- a/src/shared/components/ui/toaster.tsx
+++ b/src/shared/components/ui/toaster.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { Toast } from "./toast";
+import { useToast } from "./use-toast";
+
+export interface ToasterProps extends React.HTMLAttributes<HTMLDivElement> {
+	/**
+	 * Position of the toaster container
+	 * @default "top-right"
+	 */
+	position?:
+		| "top-right"
+		| "top-left"
+		| "bottom-right"
+		| "bottom-left"
+		| "top-center"
+		| "bottom-center";
+}
+
+const positionClasses: Record<NonNullable<ToasterProps["position"]>, string> = {
+	"top-right": "top-0 right-0",
+	"top-left": "top-0 left-0",
+	"bottom-right": "bottom-0 right-0",
+	"bottom-left": "bottom-0 left-0",
+	"top-center": "top-0 left-1/2 -translate-x-1/2",
+	"bottom-center": "bottom-0 left-1/2 -translate-x-1/2",
+};
+
+const Toaster = React.forwardRef<HTMLDivElement, ToasterProps>(
+	({ className, position = "top-right", ...props }, ref) => {
+		const { toasts, dismiss } = useToast();
+
+		if (toasts.length === 0) {
+			return null;
+		}
+
+		return (
+			<div
+				ref={ref}
+				className={cn(
+					"fixed z-50 flex max-h-screen w-full flex-col gap-2 p-4 sm:max-w-[420px]",
+					positionClasses[position],
+					className,
+				)}
+				{...props}
+			>
+				{toasts.map((toast) => (
+					<Toast key={toast.id} toast={toast} onDismiss={dismiss} />
+				))}
+			</div>
+		);
+	},
+);
+Toaster.displayName = "Toaster";
+
+export { Toaster };

--- a/src/shared/components/ui/use-toast.ts
+++ b/src/shared/components/ui/use-toast.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type ToastVariant = "success" | "error" | "warning" | "info";
+
+export interface Toast {
+	id: string;
+	title: string;
+	description?: string;
+	variant: ToastVariant;
+	duration?: number;
+}
+
+export interface ToastOptions {
+	title: string;
+	description?: string;
+	variant?: ToastVariant;
+	duration?: number;
+}
+
+type ToastListener = (toasts: Toast[]) => void;
+
+const DEFAULT_DURATION = 5000;
+
+/**
+ * グローバルなトースト状態管理
+ *
+ * 注意: グローバル変数はモジュールのライフサイクル中存在し続けます。
+ * - toasts配列: トーストが dismiss されるか dismissAll が呼ばれると適切にクリアされます
+ * - listeners Set: useToast フックの useEffect クリーンアップで確実に削除されます
+ *
+ * SPAでのページ遷移時にコンポーネントがアンマウントされても、
+ * useEffect のクリーンアップ関数により listener は削除されるため、
+ * メモリリークは発生しません。
+ */
+let toasts: Toast[] = [];
+const listeners = new Set<ToastListener>();
+
+function generateId(): string {
+	return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function notifyListeners(): void {
+	for (const listener of listeners) {
+		listener([...toasts]);
+	}
+}
+
+export function toast(options: ToastOptions): string {
+	const id = generateId();
+	const newToast: Toast = {
+		id,
+		title: options.title,
+		description: options.description,
+		variant: options.variant ?? "info",
+		duration: options.duration ?? DEFAULT_DURATION,
+	};
+
+	toasts = [...toasts, newToast];
+	notifyListeners();
+
+	return id;
+}
+
+export function dismissToast(id: string): void {
+	toasts = toasts.filter((t) => t.id !== id);
+	notifyListeners();
+}
+
+export function useToast() {
+	const [currentToasts, setCurrentToasts] = useState<Toast[]>(toasts);
+
+	useEffect(() => {
+		const listener: ToastListener = (newToasts) => {
+			setCurrentToasts(newToasts);
+		};
+		listeners.add(listener);
+
+		// クリーンアップ: コンポーネントのアンマウント時に listener を確実に削除
+		// これによりメモリリークを防止します
+		return () => {
+			listeners.delete(listener);
+		};
+	}, []);
+
+	const showToast = useCallback((options: ToastOptions) => {
+		return toast(options);
+	}, []);
+
+	const dismiss = useCallback((id: string) => {
+		dismissToast(id);
+	}, []);
+
+	const dismissAll = useCallback(() => {
+		toasts = [];
+		notifyListeners();
+	}, []);
+
+	return {
+		toasts: currentToasts,
+		toast: showToast,
+		dismiss,
+		dismissAll,
+	};
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,6 +37,12 @@
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
 
+  --color-success: hsl(var(--success));
+  --color-success-foreground: hsl(var(--success-foreground));
+
+  --color-warning: hsl(var(--warning));
+  --color-warning-foreground: hsl(var(--warning-foreground));
+
   --color-muted: hsl(var(--muted));
   --color-muted-foreground: hsl(var(--muted-foreground));
 
@@ -134,6 +140,12 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
+    --success: 142 76% 36%;
+    --success-foreground: 210 40% 98%;
+
+    --warning: 38 92% 50%;
+    --warning-foreground: 222.2 84% 4.9%;
+
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
@@ -168,6 +180,12 @@
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
+
+    --success: 142 70% 45%;
+    --success-foreground: 210 40% 98%;
+
+    --warning: 38 92% 50%;
+    --warning-foreground: 222.2 84% 4.9%;
 
     --code: #2b2b2b;
     --code-foreground: #f8f8f2;


### PR DESCRIPTION
## 概要

- BlogCard: styleタグをTailwindクラスに統一（border-border, text-muted-foreground使用）
- CategoryBadge: ハードコード色をTailwindクラスに移行、ダークモード対応追加
- Header: 固定色（bg-slate-200 dark:bg-slate-900）をCSS変数（bg-secondary）に統一
- global.css: success/warning CSS変数を追加
- 新規UIコンポーネント追加: Toast, Dialog, Alert（shadcn/uiスタイル）

## テスト計画

- [x] 型チェック（astro check）通過
- [x] Lintチェック（biome check）通過
- [ ] 開発サーバーでの動作確認
- [ ] ライト/ダークモードでの表示確認

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/claude-code)