### PR TITLE
feat: Phase 2 ブログ強化機能

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,3 +5,5 @@ pre-commit:
     lint:
       glob: "*.{ts,tsx,js,jsx,astro}"
       run: bunx biome check --staged --no-errors-on-unmatched
+    knip:
+      run: bun run knip

--- a/src/config/blog.ts
+++ b/src/config/blog.ts
@@ -36,14 +36,6 @@ export const CATEGORY_SLUG_MAP: Record<
 	Go: "go",
 };
 
-// スラッグからカテゴリ名への逆マッピング
-export const SLUG_CATEGORY_MAP: Record<
-	string,
-	(typeof BLOG_CATEGORIES)[number]
-> = Object.fromEntries(
-	Object.entries(CATEGORY_SLUG_MAP).map(([name, slug]) => [slug, name]),
-) as Record<string, (typeof BLOG_CATEGORIES)[number]>;
-
 export const BLOG_CONFIG = {
 	perPage: 10,
 	getAllLimit: 500,

--- a/src/config/blog.ts
+++ b/src/config/blog.ts
@@ -15,6 +15,35 @@ export const BLOG_CATEGORIES = [
 	"Go",
 ] as const;
 
+// カテゴリ名からスラッグへのマッピング
+export const CATEGORY_SLUG_MAP: Record<
+	(typeof BLOG_CATEGORIES)[number],
+	string
+> = {
+	React: "react",
+	Github: "github",
+	Git: "git",
+	JavaScript: "javascript",
+	TypeScript: "typescript",
+	TailwindCSS: "tailwindcss",
+	日記: "diary",
+	"Next.js": "nextjs",
+	"Node.js": "nodejs",
+	"Nest.js": "nestjs",
+	Prisma: "prisma",
+	Docker: "docker",
+	Cloudflare: "cloudflare",
+	Go: "go",
+};
+
+// スラッグからカテゴリ名への逆マッピング
+export const SLUG_CATEGORY_MAP: Record<
+	string,
+	(typeof BLOG_CATEGORIES)[number]
+> = Object.fromEntries(
+	Object.entries(CATEGORY_SLUG_MAP).map(([name, slug]) => [slug, name]),
+) as Record<string, (typeof BLOG_CATEGORIES)[number]>;
+
 export const BLOG_CONFIG = {
 	perPage: 10,
 	getAllLimit: 500,

--- a/src/features/blog/components/CategoryFilter.astro
+++ b/src/features/blog/components/CategoryFilter.astro
@@ -1,0 +1,36 @@
+---
+import { BLOG_CATEGORIES } from "@/config/blog";
+
+interface Props {
+	activeCategory?: string;
+}
+
+const { activeCategory } = Astro.props;
+---
+
+<nav aria-label="カテゴリフィルタ" class="flex flex-wrap gap-2 mb-8">
+	<a
+		href="/blogs/page/1"
+		class:list={[
+			"py-2 px-4 rounded-full text-sm no-underline transition-all",
+			!activeCategory
+				? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900"
+				: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700",
+		]}
+	>
+		すべて
+	</a>
+	{BLOG_CATEGORIES.map((category) => (
+		<a
+			href={`/blogs/category/${encodeURIComponent(category)}/page/1`}
+			class:list={[
+				"py-2 px-4 rounded-full text-sm no-underline transition-all",
+				activeCategory === category
+					? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900"
+					: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700",
+			]}
+		>
+			{category}
+		</a>
+	))}
+</nav>

--- a/src/features/blog/components/CategoryFilter.astro
+++ b/src/features/blog/components/CategoryFilter.astro
@@ -1,6 +1,7 @@
 ---
 import { BLOG_CATEGORIES, CATEGORY_SLUG_MAP, BLOG_CONFIG } from "@/config/blog";
 import { getBlogs } from "@/lib/microcms";
+import { countBlogsByCategory } from "@/utils/blog";
 
 interface CategoryCount {
 	name: (typeof BLOG_CATEGORIES)[number];
@@ -26,17 +27,7 @@ const categoriesWithCount =
 		});
 
 		// カテゴリごとの記事数を集計
-		const categoryCounts = new Map<string, number>();
-		for (const blog of allBlogs.contents) {
-			if (blog.category) {
-				const name = blog.category.name;
-				categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
-			}
-			if (blog.category2) {
-				const name = blog.category2.name;
-				categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
-			}
-		}
+		const categoryCounts = countBlogsByCategory(allBlogs.contents);
 
 		return BLOG_CATEGORIES.map((category) => ({
 			name: category,

--- a/src/features/blog/components/CategoryFilter.astro
+++ b/src/features/blog/components/CategoryFilter.astro
@@ -47,17 +47,20 @@ const categoriesWithCount =
 
 // 記事があるカテゴリのみ
 const activeCategories = categoriesWithCount.filter((c) => c.count > 0);
+
+// スタイルクラスを変数に抽出
+const baseClasses =
+	"py-2 px-4 rounded-full text-sm no-underline transition-all";
+const activeClasses =
+	"bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900";
+const inactiveClasses =
+	"bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700";
 ---
 
 <nav aria-label="カテゴリフィルタ" class="flex flex-wrap gap-2 mb-8">
 	<a
 		href="/blogs/page/1"
-		class:list={[
-			"py-2 px-4 rounded-full text-sm no-underline transition-all",
-			!activeSlug
-				? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900"
-				: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700",
-		]}
+		class:list={[baseClasses, !activeSlug ? activeClasses : inactiveClasses]}
 	>
 		すべて
 	</a>
@@ -65,12 +68,7 @@ const activeCategories = categoriesWithCount.filter((c) => c.count > 0);
 		activeCategories.map((category) => (
 			<a
 				href={`/blogs/category/${category.slug}/page/1`}
-				class:list={[
-					"py-2 px-4 rounded-full text-sm no-underline transition-all",
-					activeSlug === category.slug
-						? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900"
-						: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700",
-				]}
+				class:list={[baseClasses, activeSlug === category.slug ? activeClasses : inactiveClasses]}
 			>
 				{category.name}
 			</a>

--- a/src/features/blog/components/CategoryFilter.astro
+++ b/src/features/blog/components/CategoryFilter.astro
@@ -1,11 +1,33 @@
 ---
-import { BLOG_CATEGORIES } from "@/config/blog";
+import { BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
+import { getBlogCountByCategory } from "@/lib/microcms";
 
-interface Props {
-	activeCategory?: string;
+interface CategoryCount {
+	name: (typeof BLOG_CATEGORIES)[number];
+	slug: string;
+	count: number;
 }
 
-const { activeCategory } = Astro.props;
+interface Props {
+	activeSlug?: string;
+	categories?: CategoryCount[];
+}
+
+const { activeSlug, categories } = Astro.props;
+
+// categoriesが提供されていない場合のみAPI呼び出し（フォールバック）
+const categoriesWithCount =
+	categories ??
+	(await Promise.all(
+		BLOG_CATEGORIES.map(async (category) => ({
+			name: category,
+			slug: CATEGORY_SLUG_MAP[category],
+			count: await getBlogCountByCategory(category),
+		})),
+	));
+
+// 記事があるカテゴリのみ
+const activeCategories = categoriesWithCount.filter((c) => c.count > 0);
 ---
 
 <nav aria-label="カテゴリフィルタ" class="flex flex-wrap gap-2 mb-8">
@@ -13,24 +35,26 @@ const { activeCategory } = Astro.props;
 		href="/blogs/page/1"
 		class:list={[
 			"py-2 px-4 rounded-full text-sm no-underline transition-all",
-			!activeCategory
+			!activeSlug
 				? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900"
 				: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700",
 		]}
 	>
 		すべて
 	</a>
-	{BLOG_CATEGORIES.map((category) => (
-		<a
-			href={`/blogs/category/${encodeURIComponent(category)}/page/1`}
-			class:list={[
-				"py-2 px-4 rounded-full text-sm no-underline transition-all",
-				activeCategory === category
-					? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900"
-					: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700",
-			]}
-		>
-			{category}
-		</a>
-	))}
+	{
+		activeCategories.map((category) => (
+			<a
+				href={`/blogs/category/${category.slug}/page/1`}
+				class:list={[
+					"py-2 px-4 rounded-full text-sm no-underline transition-all",
+					activeSlug === category.slug
+						? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900"
+						: "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700",
+				]}
+			>
+				{category.name}
+			</a>
+		))
+	}
 </nav>

--- a/src/features/blog/components/CategoryFilter.astro
+++ b/src/features/blog/components/CategoryFilter.astro
@@ -1,6 +1,6 @@
 ---
-import { BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
-import { getBlogCountByCategory } from "@/lib/microcms";
+import { BLOG_CATEGORIES, CATEGORY_SLUG_MAP, BLOG_CONFIG } from "@/config/blog";
+import { getBlogs } from "@/lib/microcms";
 
 interface CategoryCount {
 	name: (typeof BLOG_CATEGORIES)[number];
@@ -18,13 +18,32 @@ const { activeSlug, categories } = Astro.props;
 // categoriesが提供されていない場合のみAPI呼び出し（フォールバック）
 const categoriesWithCount =
 	categories ??
-	(await Promise.all(
-		BLOG_CATEGORIES.map(async (category) => ({
+	(await (async () => {
+		// 全記事を1回だけ取得
+		const allBlogs = await getBlogs({
+			limit: BLOG_CONFIG.getAllLimit,
+			fields: ["id", "category", "category2"],
+		});
+
+		// カテゴリごとの記事数を集計
+		const categoryCounts = new Map<string, number>();
+		for (const blog of allBlogs.contents) {
+			if (blog.category) {
+				const name = blog.category.name;
+				categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+			}
+			if (blog.category2) {
+				const name = blog.category2.name;
+				categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+			}
+		}
+
+		return BLOG_CATEGORIES.map((category) => ({
 			name: category,
 			slug: CATEGORY_SLUG_MAP[category],
-			count: await getBlogCountByCategory(category),
-		})),
-	));
+			count: categoryCounts.get(category) || 0,
+		}));
+	})());
 
 // 記事があるカテゴリのみ
 const activeCategories = categoriesWithCount.filter((c) => c.count > 0);

--- a/src/features/blog/components/ReadingTime.astro
+++ b/src/features/blog/components/ReadingTime.astro
@@ -1,0 +1,9 @@
+---
+interface Props {
+	minutes: number;
+}
+
+const { minutes } = Astro.props;
+---
+
+<span class="text-gray-500 dark:text-gray-400 text-sm">約{minutes}分で読めます</span>

--- a/src/features/blog/components/RelatedArticles.astro
+++ b/src/features/blog/components/RelatedArticles.astro
@@ -1,0 +1,32 @@
+---
+import type { Blog } from "@/features/blog/types";
+import { formatDate } from "@/utils/date";
+
+interface Props {
+	blogs: Pick<
+		Blog,
+		"id" | "title" | "category" | "category2" | "publishedAt"
+	>[];
+}
+
+const { blogs } = Astro.props;
+---
+
+{blogs.length > 0 && (
+	<section aria-labelledby="related-title" class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700">
+		<h2 id="related-title" class="text-xl font-semibold mb-4">関連記事</h2>
+		<ul class="list-none p-0 m-0">
+			{blogs.map((blog) => (
+				<li class="mb-3">
+					<a
+						href={`/blogs/${blog.id}`}
+						class="flex justify-between items-center gap-4 py-3 px-4 bg-gray-50 dark:bg-gray-800 rounded-lg no-underline transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+					>
+						<span class="text-gray-900 dark:text-gray-100 font-medium">{blog.title}</span>
+						<span class="text-gray-500 dark:text-gray-400 text-sm whitespace-nowrap">{formatDate(blog.publishedAt)}</span>
+					</a>
+				</li>
+			))}
+		</ul>
+	</section>
+)}

--- a/src/features/blog/components/TableOfContents.astro
+++ b/src/features/blog/components/TableOfContents.astro
@@ -1,0 +1,27 @@
+---
+import type { TocItem } from "@/utils/blog";
+
+interface Props {
+	toc: TocItem[];
+}
+
+const { toc } = Astro.props;
+---
+
+{toc.length > 0 && (
+	<nav aria-label="目次" class="bg-gray-100 dark:bg-gray-800 rounded-lg p-6 mb-8">
+		<h2 class="text-base font-semibold mb-3">目次</h2>
+		<ul class="list-none p-0 m-0">
+			{toc.map((item) => (
+				<li class:list={["mb-2", { "pl-4": item.level === 3 }]}>
+					<a
+						href={`#${item.id}`}
+						class="text-gray-700 dark:text-gray-300 no-underline text-sm hover:text-gray-900 dark:hover:text-gray-100 hover:underline"
+					>
+						{item.text}
+					</a>
+				</li>
+			))}
+		</ul>
+	</nav>
+)}

--- a/src/features/blog/types.ts
+++ b/src/features/blog/types.ts
@@ -7,8 +7,8 @@ export type Blog = {
 	publishedAt: string;
 	revisedAt: string;
 	title: string;
-	category: Category;
-	category2: Category;
+	category?: Category;
+	category2?: Category;
 	body: string;
 };
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 import BaseHead from "@/shared/components/layout/BaseHead.astro";
 import Footer from "@/shared/components/layout/Footer.astro";
 import Header from "@/shared/components/layout/Header.astro";
@@ -22,7 +22,7 @@ const {
 <html lang="ja">
   <head>
     <BaseHead title={title} description={description} image={image} />
-    <ViewTransitions />
+    <ClientRouter />
     <script is:inline>
       // テーマ取得関数
       function getThemePreference() {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from "astro:transitions";
 import BaseHead from "@/shared/components/layout/BaseHead.astro";
 import Footer from "@/shared/components/layout/Footer.astro";
 import Header from "@/shared/components/layout/Header.astro";
@@ -21,6 +22,38 @@ const {
 <html lang="ja">
   <head>
     <BaseHead title={title} description={description} image={image} />
+    <ViewTransitions />
+    <script is:inline>
+      // テーマ取得関数
+      function getThemePreference() {
+        if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+          return localStorage.getItem('theme');
+        }
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+
+      // 初回読み込み時にテーマを適用
+      const isDark = getThemePreference() === 'dark';
+      document.documentElement.classList.toggle('dark', isDark);
+
+      // View Transitions: ページスワップ前に新しいドキュメントにテーマを適用
+      document.addEventListener('astro:before-swap', (event) => {
+        const isDark = getThemePreference() === 'dark';
+        event.newDocument.documentElement.classList.toggle('dark', isDark);
+      });
+
+      // テーマ変更の監視とlocalStorage保存
+      if (typeof localStorage !== 'undefined') {
+        const observer = new MutationObserver(() => {
+          const isDark = document.documentElement.classList.contains('dark');
+          localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
+        observer.observe(document.documentElement, {
+          attributes: true,
+          attributeFilter: ['class'],
+        });
+      }
+    </script>
   </head>
   <body>
     <Header />
@@ -28,31 +61,5 @@ const {
       <slot />
     </div>
     <Footer />
-    <script is:inline>
-      const getThemePreference = () => {
-        if (
-          typeof localStorage !== 'undefined' &&
-          localStorage.getItem('theme')
-        ) {
-          return localStorage.getItem('theme')
-        }
-        return window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light'
-      }
-      const isDark = getThemePreference() === 'dark'
-      document.documentElement.classList[isDark ? 'add' : 'remove']('dark')
-
-      if (typeof localStorage !== 'undefined') {
-        const observer = new MutationObserver(() => {
-          const isDark = document.documentElement.classList.contains('dark')
-          localStorage.setItem('theme', isDark ? 'dark' : 'light')
-        })
-        observer.observe(document.documentElement, {
-          attributes: true,
-          attributeFilter: ['class'],
-        })
-      }
-    </script>
   </body>
 </html>

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -52,13 +52,10 @@ export const getBlogsByCategory = async (
 	const offset = queries?.offset ?? 0;
 
 	// 全記事を取得（フィルタはJS側で行う）
-	const res = await client.get<BlogResponse>({
-		endpoint: ENDPOINTS.blog,
-		queries: {
-			limit: BLOG_CONFIG.getAllLimit,
-			orders: queries?.orders ?? "-publishedAt",
-			fields: queries?.fields,
-		},
+	const res = await getBlogs({
+		limit: BLOG_CONFIG.getAllLimit,
+		orders: queries?.orders ?? "-publishedAt",
+		fields: queries?.fields,
 	});
 
 	// カテゴリでフィルタ
@@ -87,13 +84,10 @@ export const getRelatedBlogs = async (
 	categoryName: string,
 	limit = 3,
 ) => {
-	const res = await client.get<BlogResponse>({
-		endpoint: ENDPOINTS.blog,
-		queries: {
-			limit: BLOG_CONFIG.getAllLimit,
-			orders: "-publishedAt",
-			fields: ["id", "title", "category", "category2", "publishedAt"],
-		},
+	const res = await getBlogs({
+		limit: BLOG_CONFIG.getAllLimit,
+		orders: "-publishedAt",
+		fields: ["id", "title", "category", "category2", "publishedAt"],
 	});
 
 	// カテゴリでフィルタし、現在の記事を除外

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -50,13 +50,12 @@ export const getBlogDetail = async (
  * カテゴリ別の記事数を取得
  */
 export const getBlogCountByCategory = async (categoryName: string) => {
-	const encodedCategory = encodeURIComponent(categoryName);
 	const res = await client.get<BlogResponse>({
 		endpoint: ENDPOINTS.blog,
 		queries: {
 			limit: 0,
 			fields: ["id"],
-			filters: `category[name][equals]${encodedCategory}[or]category2[name][equals]${encodedCategory}`,
+			filters: `category.name[equals]${categoryName}[or]category2.name[equals]${categoryName}`,
 		},
 	});
 	return res.totalCount;
@@ -69,12 +68,11 @@ export const getBlogsByCategory = async (
 	categoryName: string,
 	queries?: MicroCMSQueries,
 ) => {
-	const encodedCategory = encodeURIComponent(categoryName);
 	return await client.get<BlogResponse>({
 		endpoint: ENDPOINTS.blog,
 		queries: {
 			...queries,
-			filters: `category[name][equals]${encodedCategory}[or]category2[name][equals]${encodedCategory}`,
+			filters: `category.name[equals]${categoryName}[or]category2.name[equals]${categoryName}`,
 		},
 	});
 };
@@ -87,18 +85,16 @@ export const getRelatedBlogs = async (
 	categoryName: string,
 	limit = 3,
 ) => {
-	const encodedCategory = encodeURIComponent(categoryName);
 	const response = await client.get<BlogResponse>({
 		endpoint: ENDPOINTS.blog,
 		queries: {
-			limit: limit + 1, // 現在の記事を除外するために+1
+			limit: limit + 1,
 			orders: "-publishedAt",
 			fields: ["id", "title", "category", "category2", "publishedAt"],
-			filters: `category[name][equals]${encodedCategory}[or]category2[name][equals]${encodedCategory}`,
+			filters: `category.name[equals]${categoryName}[or]category2.name[equals]${categoryName}`,
 		},
 	});
 
-	// 現在の記事を除外して最大limit件返す
 	return response.contents
 		.filter((blog) => blog.id !== currentBlogId)
 		.slice(0, limit);

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -40,30 +40,9 @@ export const getBlogDetail = async (
 };
 
 /**
- * カテゴリ別の記事数を取得
+ * カテゴリ別の記事を取得
  * microCMSはリレーションフィールドのnameでフィルタできないため、
  * 全記事を取得してJSでフィルタする
- */
-export const getBlogCountByCategory = async (categoryName: string) => {
-	const res = await client.get<BlogResponse>({
-		endpoint: ENDPOINTS.blog,
-		queries: {
-			limit: BLOG_CONFIG.getAllLimit,
-			fields: ["id", "category", "category2"],
-		},
-	});
-
-	const filtered = res.contents.filter(
-		(blog) =>
-			blog.category?.name === categoryName ||
-			blog.category2?.name === categoryName,
-	);
-
-	return filtered.length;
-};
-
-/**
- * カテゴリ別の記事を取得
  */
 export const getBlogsByCategory = async (
 	categoryName: string,

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -19,14 +19,6 @@ const client = createClient({
 	apiKey: import.meta.env.MICROCMS_API_KEY,
 });
 
-export const getBlogCount = async () => {
-	const res = await client.get<BlogResponse>({
-		endpoint: ENDPOINTS.blog,
-		queries: { limit: 0, fields: ["id"] },
-	});
-	return res.totalCount;
-};
-
 export const getBlogs = async (queries?: MicroCMSQueries) => {
 	return await client.get<BlogResponse>({ endpoint: ENDPOINTS.blog, queries });
 };

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -45,3 +45,61 @@ export const getBlogDetail = async (
 		queries,
 	});
 };
+
+/**
+ * カテゴリ別の記事数を取得
+ */
+export const getBlogCountByCategory = async (categoryName: string) => {
+	const encodedCategory = encodeURIComponent(categoryName);
+	const res = await client.get<BlogResponse>({
+		endpoint: ENDPOINTS.blog,
+		queries: {
+			limit: 0,
+			fields: ["id"],
+			filters: `category[name][equals]${encodedCategory}[or]category2[name][equals]${encodedCategory}`,
+		},
+	});
+	return res.totalCount;
+};
+
+/**
+ * カテゴリ別の記事を取得
+ */
+export const getBlogsByCategory = async (
+	categoryName: string,
+	queries?: MicroCMSQueries,
+) => {
+	const encodedCategory = encodeURIComponent(categoryName);
+	return await client.get<BlogResponse>({
+		endpoint: ENDPOINTS.blog,
+		queries: {
+			...queries,
+			filters: `category[name][equals]${encodedCategory}[or]category2[name][equals]${encodedCategory}`,
+		},
+	});
+};
+
+/**
+ * 関連記事を取得（同カテゴリの記事、現在の記事を除外）
+ */
+export const getRelatedBlogs = async (
+	currentBlogId: string,
+	categoryName: string,
+	limit = 3,
+) => {
+	const encodedCategory = encodeURIComponent(categoryName);
+	const response = await client.get<BlogResponse>({
+		endpoint: ENDPOINTS.blog,
+		queries: {
+			limit: limit + 1, // 現在の記事を除外するために+1
+			orders: "-publishedAt",
+			fields: ["id", "title", "category", "category2", "publishedAt"],
+			filters: `category[name][equals]${encodedCategory}[or]category2[name][equals]${encodedCategory}`,
+		},
+	});
+
+	// 現在の記事を除外して最大limit件返す
+	return response.contents
+		.filter((blog) => blog.id !== currentBlogId)
+		.slice(0, limit);
+};

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -14,6 +14,25 @@ type BlogResponse = {
 	contents: Blog[];
 };
 
+// ビルド時のAPI呼び出しを削減するためのキャッシュ
+let allBlogsCache: BlogResponse | null = null;
+
+/**
+ * 全記事をキャッシュ付きで取得
+ * キャッシュには全フィールドを含む記事を保存する（fieldsパラメータは無視される）
+ */
+async function getAllBlogsWithCache(): Promise<BlogResponse> {
+	if (allBlogsCache) {
+		return allBlogsCache;
+	}
+	const res = await getBlogs({
+		limit: BLOG_CONFIG.getAllLimit,
+		orders: "-publishedAt",
+	});
+	allBlogsCache = res;
+	return res;
+}
+
 const client = createClient({
 	serviceDomain: import.meta.env.MICROCMS_SERVICE_DOMAIN,
 	apiKey: import.meta.env.MICROCMS_API_KEY,
@@ -51,12 +70,8 @@ export const getBlogsByCategory = async (
 	const limit = queries?.limit ?? 10;
 	const offset = queries?.offset ?? 0;
 
-	// 全記事を取得（フィルタはJS側で行う）
-	const res = await getBlogs({
-		limit: BLOG_CONFIG.getAllLimit,
-		orders: queries?.orders ?? "-publishedAt",
-		fields: queries?.fields,
-	});
+	// キャッシュを利用して全記事を取得（フィルタはJS側で行う）
+	const res = await getAllBlogsWithCache();
 
 	// カテゴリでフィルタ
 	const filtered = res.contents.filter(
@@ -84,11 +99,8 @@ export const getRelatedBlogs = async (
 	categoryName: string,
 	limit = 3,
 ) => {
-	const res = await getBlogs({
-		limit: BLOG_CONFIG.getAllLimit,
-		orders: "-publishedAt",
-		fields: ["id", "title", "category", "category2", "publishedAt"],
-	});
+	// キャッシュを利用して全記事を取得
+	const res = await getAllBlogsWithCache();
 
 	// カテゴリでフィルタし、現在の記事を除外
 	const filtered = res.contents.filter(

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -1,5 +1,6 @@
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import { createClient } from "microcms-js-sdk";
+import { BLOG_CONFIG } from "@/config/blog";
 import type { Blog } from "@/features/blog/types";
 
 const ENDPOINTS = {
@@ -48,17 +49,25 @@ export const getBlogDetail = async (
 
 /**
  * カテゴリ別の記事数を取得
+ * microCMSはリレーションフィールドのnameでフィルタできないため、
+ * 全記事を取得してJSでフィルタする
  */
 export const getBlogCountByCategory = async (categoryName: string) => {
 	const res = await client.get<BlogResponse>({
 		endpoint: ENDPOINTS.blog,
 		queries: {
-			limit: 0,
-			fields: ["id"],
-			filters: `category.name[equals]${categoryName}[or]category2.name[equals]${categoryName}`,
+			limit: BLOG_CONFIG.getAllLimit,
+			fields: ["id", "category", "category2"],
 		},
 	});
-	return res.totalCount;
+
+	const filtered = res.contents.filter(
+		(blog) =>
+			blog.category?.name === categoryName ||
+			blog.category2?.name === categoryName,
+	);
+
+	return filtered.length;
 };
 
 /**
@@ -68,13 +77,35 @@ export const getBlogsByCategory = async (
 	categoryName: string,
 	queries?: MicroCMSQueries,
 ) => {
-	return await client.get<BlogResponse>({
+	const limit = queries?.limit ?? 10;
+	const offset = queries?.offset ?? 0;
+
+	// 全記事を取得（フィルタはJS側で行う）
+	const res = await client.get<BlogResponse>({
 		endpoint: ENDPOINTS.blog,
 		queries: {
-			...queries,
-			filters: `category.name[equals]${categoryName}[or]category2.name[equals]${categoryName}`,
+			limit: BLOG_CONFIG.getAllLimit,
+			orders: queries?.orders ?? "-publishedAt",
+			fields: queries?.fields,
 		},
 	});
+
+	// カテゴリでフィルタ
+	const filtered = res.contents.filter(
+		(blog) =>
+			blog.category?.name === categoryName ||
+			blog.category2?.name === categoryName,
+	);
+
+	// ページネーション適用
+	const paged = filtered.slice(offset, offset + limit);
+
+	return {
+		contents: paged,
+		totalCount: filtered.length,
+		offset,
+		limit,
+	};
 };
 
 /**
@@ -85,17 +116,22 @@ export const getRelatedBlogs = async (
 	categoryName: string,
 	limit = 3,
 ) => {
-	const response = await client.get<BlogResponse>({
+	const res = await client.get<BlogResponse>({
 		endpoint: ENDPOINTS.blog,
 		queries: {
-			limit: limit + 1,
+			limit: BLOG_CONFIG.getAllLimit,
 			orders: "-publishedAt",
 			fields: ["id", "title", "category", "category2", "publishedAt"],
-			filters: `category.name[equals]${categoryName}[or]category2.name[equals]${categoryName}`,
 		},
 	});
 
-	return response.contents
-		.filter((blog) => blog.id !== currentBlogId)
-		.slice(0, limit);
+	// カテゴリでフィルタし、現在の記事を除外
+	const filtered = res.contents.filter(
+		(blog) =>
+			blog.id !== currentBlogId &&
+			(blog.category?.name === categoryName ||
+				blog.category2?.name === categoryName),
+	);
+
+	return filtered.slice(0, limit);
 };

--- a/src/pages/blogs/[id].astro
+++ b/src/pages/blogs/[id].astro
@@ -29,6 +29,9 @@ const relatedBlogs = categoryName
 	? await getRelatedBlogs(blog.id, categoryName, 3)
 	: [];
 
+// 読了時間は元のHTMLから計算（DOM操作前）
+const readingTime = calculateReadingTime(blog.body);
+
 const $ = load(blog.body);
 
 $("div[data-filename]").each((_, element) => {
@@ -52,8 +55,8 @@ $("pre code").each((_, element) => {
 	$(element).addClass("hljs");
 });
 
-const { html: bodyWithIds, toc } = extractTableOfContents($.html());
-const readingTime = calculateReadingTime(blog.body);
+// 目次抽出はcheerioインスタンスを直接渡す（再パース不要）
+const { html: bodyWithIds, toc } = extractTableOfContents($);
 blog.body = bodyWithIds;
 ---
 

--- a/src/pages/blogs/[id].astro
+++ b/src/pages/blogs/[id].astro
@@ -1,11 +1,15 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import { getBlogDetail, getBlogs } from "@/lib/microcms";
+import { getBlogDetail, getBlogs, getRelatedBlogs } from "@/lib/microcms";
 import { formatDate } from "@/utils/date";
+import { extractTableOfContents, calculateReadingTime } from "@/utils/blog";
 import { load } from "cheerio";
 import hljs, { type HighlightResult } from "highlight.js";
 import "highlight.js/styles/a11y-dark.css";
 import CategoryBadge from "@/features/blog/components/CategoryBadge.astro";
+import TableOfContents from "@/features/blog/components/TableOfContents.astro";
+import ReadingTime from "@/features/blog/components/ReadingTime.astro";
+import RelatedArticles from "@/features/blog/components/RelatedArticles.astro";
 import { BLOG_CONFIG } from "@/config/blog";
 
 export async function getStaticPaths() {
@@ -18,6 +22,12 @@ export async function getStaticPaths() {
 
 const { id } = Astro.params;
 const blog = await getBlogDetail(id);
+
+// 関連記事を取得（category または category2 が存在する場合）
+const categoryName = blog.category?.name || blog.category2?.name;
+const relatedBlogs = categoryName
+	? await getRelatedBlogs(blog.id, categoryName, 3)
+	: [];
 
 const $ = load(blog.body);
 
@@ -42,30 +52,41 @@ $("pre code").each((_, element) => {
 	$(element).addClass("hljs");
 });
 
-blog.body = $.html();
+const { html: bodyWithIds, toc } = extractTableOfContents($.html());
+const readingTime = calculateReadingTime(blog.body);
+blog.body = bodyWithIds;
 ---
 
 <BaseLayout>
-  <main>
-    <h1>{blog.title}</h1>
-    <div class="flex">
-      <div>
-        <div>
-          {blog.category && <CategoryBadge {...blog.category} />}
-          {blog.category2 && <CategoryBadge {...blog.category2} />}
-        </div>
-      </div>
-      <p>公開日時:{formatDate(blog.publishedAt)}</p>
-    </div>
-    <div class="space-y-4 py-12" set:html={blog.body} />
-  </main>
+	<main>
+		<h1>{blog.title}</h1>
+		<div class="meta">
+			<div class="categories">
+				{blog.category && <CategoryBadge {...blog.category} />}
+				{blog.category2 && <CategoryBadge {...blog.category2} />}
+			</div>
+			<div class="info">
+				<p>公開日時:{formatDate(blog.publishedAt)}</p>
+				<ReadingTime minutes={readingTime} />
+			</div>
+		</div>
+		<TableOfContents toc={toc} />
+		<div class="space-y-4 py-12" set:html={blog.body} />
+		<RelatedArticles blogs={relatedBlogs} />
+	</main>
 </BaseLayout>
 
 <style>
-  .flex {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-  }
+	.meta {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.info {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
 </style>

--- a/src/pages/blogs/category/[category]/page/[page].astro
+++ b/src/pages/blogs/category/[category]/page/[page].astro
@@ -10,7 +10,7 @@ import {
 	PaginationNext,
 	PaginationPrevious,
 } from "@/shared/components/ui/pagination";
-import { BLOG_CONFIG, BLOG_CATEGORIES } from "@/config/blog";
+import { BLOG_CONFIG, BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBlogCountByCategory, getBlogsByCategory } from "@/lib/microcms";
 
@@ -19,14 +19,23 @@ const PAGINATION_OFFSET = 2;
 export async function getStaticPaths() {
 	const paths = [];
 
-	for (const category of BLOG_CATEGORIES) {
-		const totalCount = await getBlogCountByCategory(category);
-		if (totalCount === 0) continue; // 記事がないカテゴリはスキップ
+	// カテゴリカウントを1回だけ取得
+	const allCategories = await Promise.all(
+		BLOG_CATEGORIES.map(async (category) => ({
+			name: category,
+			slug: CATEGORY_SLUG_MAP[category],
+			count: await getBlogCountByCategory(category),
+		})),
+	);
 
-		const pages = Math.ceil(totalCount / BLOG_CONFIG.perPage);
+	for (const cat of allCategories) {
+		if (cat.count === 0) continue;
+
+		const pages = Math.ceil(cat.count / BLOG_CONFIG.perPage);
 		for (let i = 1; i <= pages; i++) {
 			paths.push({
-				params: { category, page: i.toString() },
+				params: { category: cat.slug, page: i.toString() },
+				props: { categoryName: cat.name, categories: allCategories },
 			});
 		}
 	}
@@ -34,9 +43,10 @@ export async function getStaticPaths() {
 	return paths;
 }
 
-const { category, page } = Astro.params;
+const { category: slug, page } = Astro.params;
+const { categoryName, categories } = Astro.props;
 
-const response = await getBlogsByCategory(category, {
+const response = await getBlogsByCategory(categoryName, {
 	limit: BLOG_CONFIG.perPage,
 	offset: (Number.parseInt(page, 10) - 1) * BLOG_CONFIG.perPage,
 	orders: "-publishedAt",
@@ -61,22 +71,20 @@ const makePaginationLinks = (currentPage: string) => {
 		startPage = Math.max(min, max - 2 * PAGINATION_OFFSET);
 	}
 
-	const encodedCategory = encodeURIComponent(category);
 	return Array.from({ length: endPage - startPage + 1 }, (_, i) => ({
 		page: startPage + i,
-		href: `/blogs/category/${encodedCategory}/page/${startPage + i}`,
+		href: `/blogs/category/${slug}/page/${startPage + i}`,
 		isCurrent: startPage + i === currentPageNum,
 	}));
 };
 
 const paginationLinks = makePaginationLinks(page);
-const encodedCategory = encodeURIComponent(category);
 ---
 
 <BaseLayout>
 	<main class="space-y-8">
-		<h1>{category} の記事一覧</h1>
-		<CategoryFilter activeCategory={category} />
+		<h1>{categoryName} の記事一覧</h1>
+		<CategoryFilter activeSlug={slug} categories={categories} />
 		<ul class="grid-container">
 			{
 				response.contents.map((blog) => (
@@ -93,7 +101,7 @@ const encodedCategory = encodeURIComponent(category);
 						!isFirstPage && (
 							<PaginationItem>
 								<PaginationPrevious
-									href={`/blogs/category/${encodedCategory}/page/${Number.parseInt(page) - 1}`}
+									href={`/blogs/category/${slug}/page/${Number.parseInt(page) - 1}`}
 								/>
 							</PaginationItem>
 						)
@@ -102,7 +110,7 @@ const encodedCategory = encodeURIComponent(category);
 						Number.parseInt(page) - PAGINATION_OFFSET > 1 && (
 							<>
 								<PaginationItem>
-									<PaginationLink href={`/blogs/category/${encodedCategory}/page/1`}>1</PaginationLink>
+									<PaginationLink href={`/blogs/category/${slug}/page/1`}>1</PaginationLink>
 								</PaginationItem>
 								<PaginationItem>
 									<PaginationEllipsis />
@@ -130,7 +138,7 @@ const encodedCategory = encodeURIComponent(category);
 								</PaginationItem>
 								<PaginationItem>
 									<PaginationLink
-										href={`/blogs/category/${encodedCategory}/page/${totalPages}`}
+										href={`/blogs/category/${slug}/page/${totalPages}`}
 									>
 										{totalPages}
 									</PaginationLink>
@@ -142,7 +150,7 @@ const encodedCategory = encodeURIComponent(category);
 						!isLastPage && (
 							<PaginationItem>
 								<PaginationNext
-									href={`/blogs/category/${encodedCategory}/page/${Number.parseInt(page) + 1}`}
+									href={`/blogs/category/${slug}/page/${Number.parseInt(page) + 1}`}
 								/>
 							</PaginationItem>
 						)

--- a/src/pages/blogs/category/[category]/page/[page].astro
+++ b/src/pages/blogs/category/[category]/page/[page].astro
@@ -12,21 +12,37 @@ import {
 } from "@/shared/components/ui/pagination";
 import { BLOG_CONFIG, BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import { getBlogCountByCategory, getBlogsByCategory } from "@/lib/microcms";
+import { getBlogs, getBlogsByCategory } from "@/lib/microcms";
 
 const PAGINATION_OFFSET = 2;
 
 export async function getStaticPaths() {
 	const paths = [];
 
-	// カテゴリカウントを1回だけ取得
-	const allCategories = await Promise.all(
-		BLOG_CATEGORIES.map(async (category) => ({
-			name: category,
-			slug: CATEGORY_SLUG_MAP[category],
-			count: await getBlogCountByCategory(category),
-		})),
-	);
+	// 全記事を1回だけ取得
+	const allBlogs = await getBlogs({
+		limit: BLOG_CONFIG.getAllLimit,
+		fields: ["id", "category", "category2"],
+	});
+
+	// カテゴリごとの記事数を集計
+	const categoryCounts = new Map<string, number>();
+	for (const blog of allBlogs.contents) {
+		if (blog.category) {
+			const name = blog.category.name;
+			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+		}
+		if (blog.category2) {
+			const name = blog.category2.name;
+			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+		}
+	}
+
+	const allCategories = BLOG_CATEGORIES.map((category) => ({
+		name: category,
+		slug: CATEGORY_SLUG_MAP[category],
+		count: categoryCounts.get(category) || 0,
+	}));
 
 	for (const cat of allCategories) {
 		if (cat.count === 0) continue;

--- a/src/pages/blogs/category/[category]/page/[page].astro
+++ b/src/pages/blogs/category/[category]/page/[page].astro
@@ -1,0 +1,172 @@
+---
+import BlogCard from "@/features/blog/components/BlogCard.astro";
+import CategoryFilter from "@/features/blog/components/CategoryFilter.astro";
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "@/shared/components/ui/pagination";
+import { BLOG_CONFIG, BLOG_CATEGORIES } from "@/config/blog";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { getBlogCountByCategory, getBlogsByCategory } from "@/lib/microcms";
+
+const PAGINATION_OFFSET = 2;
+
+export async function getStaticPaths() {
+	const paths = [];
+
+	for (const category of BLOG_CATEGORIES) {
+		const totalCount = await getBlogCountByCategory(category);
+		if (totalCount === 0) continue; // 記事がないカテゴリはスキップ
+
+		const pages = Math.ceil(totalCount / BLOG_CONFIG.perPage);
+		for (let i = 1; i <= pages; i++) {
+			paths.push({
+				params: { category, page: i.toString() },
+			});
+		}
+	}
+
+	return paths;
+}
+
+const { category, page } = Astro.params;
+
+const response = await getBlogsByCategory(category, {
+	limit: BLOG_CONFIG.perPage,
+	offset: (Number.parseInt(page, 10) - 1) * BLOG_CONFIG.perPage,
+	orders: "-publishedAt",
+	fields: ["id", "title", "category", "category2", "publishedAt"],
+});
+
+const totalPages = Math.ceil(response.totalCount / BLOG_CONFIG.perPage);
+const isFirstPage = page === "1";
+const isLastPage = page === totalPages.toString();
+
+const makePaginationLinks = (currentPage: string) => {
+	const min = 1;
+	const max = totalPages;
+	const currentPageNum = Number.parseInt(currentPage, 10);
+
+	let startPage = Math.max(min, currentPageNum - PAGINATION_OFFSET);
+	let endPage = Math.min(max, currentPageNum + PAGINATION_OFFSET);
+
+	if (startPage === min) {
+		endPage = Math.min(max, min + 2 * PAGINATION_OFFSET);
+	} else if (endPage === max) {
+		startPage = Math.max(min, max - 2 * PAGINATION_OFFSET);
+	}
+
+	const encodedCategory = encodeURIComponent(category);
+	return Array.from({ length: endPage - startPage + 1 }, (_, i) => ({
+		page: startPage + i,
+		href: `/blogs/category/${encodedCategory}/page/${startPage + i}`,
+		isCurrent: startPage + i === currentPageNum,
+	}));
+};
+
+const paginationLinks = makePaginationLinks(page);
+const encodedCategory = encodeURIComponent(category);
+---
+
+<BaseLayout>
+	<main class="space-y-8">
+		<h1>{category} の記事一覧</h1>
+		<CategoryFilter activeCategory={category} />
+		<ul class="grid-container">
+			{
+				response.contents.map((blog) => (
+					<li>
+						<BlogCard {...blog} />
+					</li>
+				))
+			}
+		</ul>
+		{totalPages > 1 && (
+			<Pagination>
+				<PaginationContent>
+					{
+						!isFirstPage && (
+							<PaginationItem>
+								<PaginationPrevious
+									href={`/blogs/category/${encodedCategory}/page/${Number.parseInt(page) - 1}`}
+								/>
+							</PaginationItem>
+						)
+					}
+					{
+						Number.parseInt(page) - PAGINATION_OFFSET > 1 && (
+							<>
+								<PaginationItem>
+									<PaginationLink href={`/blogs/category/${encodedCategory}/page/1`}>1</PaginationLink>
+								</PaginationItem>
+								<PaginationItem>
+									<PaginationEllipsis />
+								</PaginationItem>
+							</>
+						)
+					}
+					{
+						paginationLinks.map((link) => (
+							<PaginationItem>
+								<PaginationLink
+									href={!link.isCurrent ? link.href : undefined}
+									isActive={link.isCurrent}
+								>
+									{link.page}
+								</PaginationLink>
+							</PaginationItem>
+						))
+					}
+					{
+						Number.parseInt(page) + PAGINATION_OFFSET < totalPages && (
+							<>
+								<PaginationItem>
+									<PaginationEllipsis />
+								</PaginationItem>
+								<PaginationItem>
+									<PaginationLink
+										href={`/blogs/category/${encodedCategory}/page/${totalPages}`}
+									>
+										{totalPages}
+									</PaginationLink>
+								</PaginationItem>
+							</>
+						)
+					}
+					{
+						!isLastPage && (
+							<PaginationItem>
+								<PaginationNext
+									href={`/blogs/category/${encodedCategory}/page/${Number.parseInt(page) + 1}`}
+								/>
+							</PaginationItem>
+						)
+					}
+				</PaginationContent>
+			</Pagination>
+		)}
+	</main>
+</BaseLayout>
+
+<style>
+	ul {
+		list-style: none;
+		padding-left: 0;
+	}
+	.grid-container {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1rem;
+	}
+
+	@media (width < 768px) {
+		.grid-container {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/src/pages/blogs/category/[category]/page/[page].astro
+++ b/src/pages/blogs/category/[category]/page/[page].astro
@@ -13,6 +13,7 @@ import {
 import { BLOG_CONFIG, BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBlogs, getBlogsByCategory } from "@/lib/microcms";
+import { countBlogsByCategory } from "@/utils/blog";
 
 const PAGINATION_OFFSET = 2;
 
@@ -26,17 +27,7 @@ export async function getStaticPaths() {
 	});
 
 	// カテゴリごとの記事数を集計
-	const categoryCounts = new Map<string, number>();
-	for (const blog of allBlogs.contents) {
-		if (blog.category) {
-			const name = blog.category.name;
-			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
-		}
-		if (blog.category2) {
-			const name = blog.category2.name;
-			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
-		}
-	}
+	const categoryCounts = countBlogsByCategory(allBlogs.contents);
 
 	const allCategories = BLOG_CATEGORIES.map((category) => ({
 		name: category,

--- a/src/pages/blogs/category/[category]/page/[page].astro
+++ b/src/pages/blogs/category/[category]/page/[page].astro
@@ -61,25 +61,25 @@ export async function getStaticPaths() {
 
 const { category: slug, page } = Astro.params;
 const { categoryName, categories } = Astro.props;
+const currentPage = Number.parseInt(page, 10);
 
 const response = await getBlogsByCategory(categoryName, {
 	limit: BLOG_CONFIG.perPage,
-	offset: (Number.parseInt(page, 10) - 1) * BLOG_CONFIG.perPage,
+	offset: (currentPage - 1) * BLOG_CONFIG.perPage,
 	orders: "-publishedAt",
 	fields: ["id", "title", "category", "category2", "publishedAt"],
 });
 
 const totalPages = Math.ceil(response.totalCount / BLOG_CONFIG.perPage);
-const isFirstPage = page === "1";
-const isLastPage = page === totalPages.toString();
+const isFirstPage = currentPage === 1;
+const isLastPage = currentPage === totalPages;
 
-const makePaginationLinks = (currentPage: string) => {
+const makePaginationLinks = () => {
 	const min = 1;
 	const max = totalPages;
-	const currentPageNum = Number.parseInt(currentPage, 10);
 
-	let startPage = Math.max(min, currentPageNum - PAGINATION_OFFSET);
-	let endPage = Math.min(max, currentPageNum + PAGINATION_OFFSET);
+	let startPage = Math.max(min, currentPage - PAGINATION_OFFSET);
+	let endPage = Math.min(max, currentPage + PAGINATION_OFFSET);
 
 	if (startPage === min) {
 		endPage = Math.min(max, min + 2 * PAGINATION_OFFSET);
@@ -90,11 +90,11 @@ const makePaginationLinks = (currentPage: string) => {
 	return Array.from({ length: endPage - startPage + 1 }, (_, i) => ({
 		page: startPage + i,
 		href: `/blogs/category/${slug}/page/${startPage + i}`,
-		isCurrent: startPage + i === currentPageNum,
+		isCurrent: startPage + i === currentPage,
 	}));
 };
 
-const paginationLinks = makePaginationLinks(page);
+const paginationLinks = makePaginationLinks();
 ---
 
 <BaseLayout>
@@ -117,13 +117,13 @@ const paginationLinks = makePaginationLinks(page);
 						!isFirstPage && (
 							<PaginationItem>
 								<PaginationPrevious
-									href={`/blogs/category/${slug}/page/${Number.parseInt(page) - 1}`}
+									href={`/blogs/category/${slug}/page/${currentPage - 1}`}
 								/>
 							</PaginationItem>
 						)
 					}
 					{
-						Number.parseInt(page) - PAGINATION_OFFSET > 1 && (
+						currentPage - PAGINATION_OFFSET > 1 && (
 							<>
 								<PaginationItem>
 									<PaginationLink href={`/blogs/category/${slug}/page/1`}>1</PaginationLink>
@@ -147,7 +147,7 @@ const paginationLinks = makePaginationLinks(page);
 						))
 					}
 					{
-						Number.parseInt(page) + PAGINATION_OFFSET < totalPages && (
+						currentPage + PAGINATION_OFFSET < totalPages && (
 							<>
 								<PaginationItem>
 									<PaginationEllipsis />
@@ -166,7 +166,7 @@ const paginationLinks = makePaginationLinks(page);
 						!isLastPage && (
 							<PaginationItem>
 								<PaginationNext
-									href={`/blogs/category/${slug}/page/${Number.parseInt(page) + 1}`}
+									href={`/blogs/category/${slug}/page/${currentPage + 1}`}
 								/>
 							</PaginationItem>
 						)

--- a/src/pages/blogs/page/[page].astro
+++ b/src/pages/blogs/page/[page].astro
@@ -10,21 +10,33 @@ import {
 	PaginationNext,
 	PaginationPrevious,
 } from "@/shared/components/ui/pagination";
-import { BLOG_CONFIG } from "@/config/blog";
+import { BLOG_CONFIG, BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import { getBlogCount, getBlogs } from "@/lib/microcms";
+import { getBlogCount, getBlogs, getBlogCountByCategory } from "@/lib/microcms";
 
 const PAGINATION_OFFSET = 2;
 
 export async function getStaticPaths() {
 	const totalCount = await getBlogCount();
 	const pages = Math.ceil(totalCount / BLOG_CONFIG.perPage);
+
+	// カテゴリカウントを1回だけ取得
+	const categories = await Promise.all(
+		BLOG_CATEGORIES.map(async (category) => ({
+			name: category,
+			slug: CATEGORY_SLUG_MAP[category],
+			count: await getBlogCountByCategory(category),
+		})),
+	);
+
 	return Array.from({ length: pages }, (_, i) => ({
 		params: { page: (i + 1).toString() },
+		props: { categories },
 	}));
 }
 
 const { page } = Astro.params;
+const { categories } = Astro.props;
 
 const response = await getBlogs({
 	limit: BLOG_CONFIG.perPage,
@@ -64,7 +76,7 @@ const paginationLinks = makePaginationLinks(page);
 <BaseLayout>
   <main class="space-y-8">
     <h1>一覧</h1>
-    <CategoryFilter />
+    <CategoryFilter categories={categories} />
     <ul class="grid-container">
       {
         response.contents.map((blog) => (

--- a/src/pages/blogs/page/[page].astro
+++ b/src/pages/blogs/page/[page].astro
@@ -1,5 +1,6 @@
 ---
 import BlogCard from "@/features/blog/components/BlogCard.astro";
+import CategoryFilter from "@/features/blog/components/CategoryFilter.astro";
 import {
 	Pagination,
 	PaginationContent,
@@ -63,6 +64,7 @@ const paginationLinks = makePaginationLinks(page);
 <BaseLayout>
   <main class="space-y-8">
     <h1>一覧</h1>
+    <CategoryFilter />
     <ul class="grid-container">
       {
         response.contents.map((blog) => (

--- a/src/pages/blogs/page/[page].astro
+++ b/src/pages/blogs/page/[page].astro
@@ -12,22 +12,38 @@ import {
 } from "@/shared/components/ui/pagination";
 import { BLOG_CONFIG, BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
 import BaseLayout from "@/layouts/BaseLayout.astro";
-import { getBlogCount, getBlogs, getBlogCountByCategory } from "@/lib/microcms";
+import { getBlogs } from "@/lib/microcms";
 
 const PAGINATION_OFFSET = 2;
 
 export async function getStaticPaths() {
-	const totalCount = await getBlogCount();
-	const pages = Math.ceil(totalCount / BLOG_CONFIG.perPage);
+	// 全記事を1回だけ取得
+	const allBlogs = await getBlogs({
+		limit: BLOG_CONFIG.getAllLimit,
+		fields: ["id", "category", "category2"],
+	});
 
-	// カテゴリカウントを1回だけ取得
-	const categories = await Promise.all(
-		BLOG_CATEGORIES.map(async (category) => ({
-			name: category,
-			slug: CATEGORY_SLUG_MAP[category],
-			count: await getBlogCountByCategory(category),
-		})),
-	);
+	// カテゴリごとの記事数を集計
+	const categoryCounts = new Map<string, number>();
+	for (const blog of allBlogs.contents) {
+		if (blog.category) {
+			const name = blog.category.name;
+			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+		}
+		if (blog.category2) {
+			const name = blog.category2.name;
+			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+		}
+	}
+
+	const categories = BLOG_CATEGORIES.map((category) => ({
+		name: category,
+		slug: CATEGORY_SLUG_MAP[category],
+		count: categoryCounts.get(category) || 0,
+	}));
+
+	const totalCount = allBlogs.totalCount;
+	const pages = Math.ceil(totalCount / BLOG_CONFIG.perPage);
 
 	return Array.from({ length: pages }, (_, i) => ({
 		params: { page: (i + 1).toString() },

--- a/src/pages/blogs/page/[page].astro
+++ b/src/pages/blogs/page/[page].astro
@@ -13,6 +13,7 @@ import {
 import { BLOG_CONFIG, BLOG_CATEGORIES, CATEGORY_SLUG_MAP } from "@/config/blog";
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getBlogs } from "@/lib/microcms";
+import { countBlogsByCategory } from "@/utils/blog";
 
 const PAGINATION_OFFSET = 2;
 
@@ -24,17 +25,7 @@ export async function getStaticPaths() {
 	});
 
 	// カテゴリごとの記事数を集計
-	const categoryCounts = new Map<string, number>();
-	for (const blog of allBlogs.contents) {
-		if (blog.category) {
-			const name = blog.category.name;
-			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
-		}
-		if (blog.category2) {
-			const name = blog.category2.name;
-			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
-		}
-	}
+	const categoryCounts = countBlogsByCategory(allBlogs.contents);
 
 	const categories = BLOG_CATEGORIES.map((category) => ({
 		name: category,

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,0 +1,42 @@
+import { load } from "cheerio";
+
+export type TocItem = {
+	id: string;
+	text: string;
+	level: number;
+};
+
+/**
+ * HTML文字列からh2, h3見出しを抽出し、IDを付与したHTMLと目次データを返す
+ */
+export function extractTableOfContents(html: string): {
+	html: string;
+	toc: TocItem[];
+} {
+	const $ = load(html);
+	const toc: TocItem[] = [];
+
+	$("h2, h3").each((index, element) => {
+		const $el = $(element);
+		const text = $el.text();
+		const level = element.tagName === "h2" ? 2 : 3;
+		const id = `heading-${index}`;
+
+		$el.attr("id", id);
+		toc.push({ id, text, level });
+	});
+
+	return { html: $.html(), toc };
+}
+
+/**
+ * HTML文字列から読了時間（分）を計算する
+ * 約500文字/分で計算
+ */
+export function calculateReadingTime(html: string): number {
+	const $ = load(html);
+	const text = $.text();
+	const charCount = text.replace(/\s/g, "").length;
+	const minutes = Math.ceil(charCount / 500);
+	return Math.max(1, minutes); // 最低1分
+}

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,4 +1,5 @@
 import { type CheerioAPI, load } from "cheerio";
+import type { Blog } from "@/features/blog/types";
 
 export type TocItem = {
 	id: string;
@@ -39,4 +40,25 @@ export function calculateReadingTime(html: string): number {
 	const charCount = text.replace(/\s/g, "").length;
 	const minutes = Math.ceil(charCount / 500);
 	return Math.max(1, minutes); // 最低1分
+}
+
+/**
+ * ブログ記事のカテゴリごとの記事数を集計する
+ * category と category2 の両方をカウントする
+ */
+export function countBlogsByCategory(
+	blogs: Pick<Blog, "category" | "category2">[],
+): Map<string, number> {
+	const categoryCounts = new Map<string, number>();
+	for (const blog of blogs) {
+		if (blog.category) {
+			const name = blog.category.name;
+			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+		}
+		if (blog.category2) {
+			const name = blog.category2.name;
+			categoryCounts.set(name, (categoryCounts.get(name) || 0) + 1);
+		}
+	}
+	return categoryCounts;
 }

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,4 +1,4 @@
-import { load } from "cheerio";
+import { type CheerioAPI, load } from "cheerio";
 
 export type TocItem = {
 	id: string;
@@ -7,13 +7,13 @@ export type TocItem = {
 };
 
 /**
- * HTML文字列からh2, h3見出しを抽出し、IDを付与したHTMLと目次データを返す
+ * HTML文字列またはCheerioインスタンスからh2, h3見出しを抽出し、IDを付与したHTMLと目次データを返す
  */
-export function extractTableOfContents(html: string): {
+export function extractTableOfContents(input: string | CheerioAPI): {
 	html: string;
 	toc: TocItem[];
 } {
-	const $ = load(html);
+	const $ = typeof input === "string" ? load(input) : input;
 	const toc: TocItem[] = [];
 
 	$("h2, h3").each((index, element) => {


### PR DESCRIPTION
## 概要

Issue #3 の Phase 2 要件に基づき、ブログ強化機能を実装しました。

- **カテゴリフィルタ**: ブログ一覧ページにカテゴリ選択UI、カテゴリ別ページ `/blogs/category/[category]/page/[page]` の静的生成
- **関連記事**: 記事詳細ページに同カテゴリの記事を最大3件表示（現在の記事は除外、新しい順）
- **目次**: h2/h3見出しから目次を自動生成（cheerioでID付与）
- **読了時間**: 文字数ベースで計算（約500文字/分）

### 新規ファイル

| ファイル | 説明 |
|---------|------|
| `src/utils/blog.ts` | 目次抽出・読了時間計算ユーティリティ |
| `src/features/blog/components/TableOfContents.astro` | 目次コンポーネント |
| `src/features/blog/components/ReadingTime.astro` | 読了時間コンポーネント |
| `src/features/blog/components/RelatedArticles.astro` | 関連記事コンポーネント |
| `src/features/blog/components/CategoryFilter.astro` | カテゴリフィルタUI |
| `src/pages/blogs/category/[category]/page/[page].astro` | カテゴリ別記事一覧ページ |

### 修正ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/lib/microcms.ts` | `getBlogCountByCategory`, `getBlogsByCategory`, `getRelatedBlogs` を追加 |
| `src/pages/blogs/[id].astro` | 目次・読了時間・関連記事を統合 |
| `src/pages/blogs/page/[page].astro` | カテゴリフィルタUIを追加 |
| `src/features/blog/types.ts` | `category`, `category2` をオプショナルに変更 |

## テスト計画

- [x] Lint（Biome）チェック通過
- [x] 型チェック（astro check）通過
- [x] 未使用コード検出（knip）通過
- [ ] 開発サーバーで目次・読了時間が表示されることを確認
- [ ] 開発サーバーで関連記事が表示されることを確認
- [ ] 開発サーバーでカテゴリフィルタが機能することを確認
- [ ] ビルド成功を確認

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)