### PR TITLE
fix: 環境変数をastro:env APIに移行

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,7 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import icon from "astro-icon";
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
@@ -22,5 +22,17 @@ export default defineConfig({
 	],
 	vite: {
 		plugins: [tailwindcss()],
+	},
+	env: {
+		schema: {
+			MICROCMS_SERVICE_DOMAIN: envField.string({
+				context: "server",
+				access: "secret",
+			}),
+			MICROCMS_API_KEY: envField.string({
+				context: "server",
+				access: "secret",
+			}),
+		},
 	},
 });

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -1,3 +1,4 @@
+import { MICROCMS_API_KEY, MICROCMS_SERVICE_DOMAIN } from "astro:env/server";
 import type { MicroCMSQueries } from "microcms-js-sdk";
 import { createClient } from "microcms-js-sdk";
 import { BLOG_CONFIG } from "@/config/blog";
@@ -34,8 +35,8 @@ async function getAllBlogsWithCache(): Promise<BlogResponse> {
 }
 
 const client = createClient({
-	serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN ?? "",
-	apiKey: process.env.MICROCMS_API_KEY ?? "",
+	serviceDomain: MICROCMS_SERVICE_DOMAIN,
+	apiKey: MICROCMS_API_KEY,
 });
 
 export const getBlogs = async (queries?: MicroCMSQueries) => {


### PR DESCRIPTION
## 概要

- Astro v6では `.env` ファイルの非公開変数が `process.env` に自動ロードされなくなったため、`astro:env` APIに移行
- `astro.config.mjs` に `env.schema` を追加し、`MICROCMS_SERVICE_DOMAIN` と `MICROCMS_API_KEY` をサーバーシークレットとして定義
- `src/lib/microcms.ts` で `process.env` の代わりに `astro:env/server` からimport

## テスト計画

- [x] `bun run check` (Biome lint): パス
- [x] `bun run knip` (未使用コード検出): パス
- [x] `bun run dev` でdevサーバー正常起動、トップページ200レスポンス確認
- [ ] 全ページの動作確認
- [ ] CIパス確認

Generated with [Claude Code](https://claude.com/claude-code)